### PR TITLE
Support implicit conversion for Synthetics

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -168,11 +168,11 @@ class ExtractSemanticDB extends Phase:
                 // ignore rhs
 
               // `given Int` (syntax sugar of `given given_Int: Int`)
-              case tree: ValDef if tree.symbol.isInventedGiven =>
-                synth.tryFindSynthetic(tree).foreach { synth =>
-                  synthetics += synth
-                }
-                traverse(tree.tpt)
+              case tree: ValDef if isInventedGiven(tree) =>
+                  synth.tryFindSynthetic(tree).foreach { synth =>
+                    synthetics += synth
+                  }
+                  traverse(tree.tpt)
               case PatternValDef(pat, rhs) =>
                 traverse(rhs)
                 PatternValDef.collectPats(pat).foreach(traverse)
@@ -333,24 +333,6 @@ class ExtractSemanticDB extends Phase:
         registerOccurrence(sname, finalSpan, SymbolOccurrence.Role.DEFINITION, treeSource)
       if !sym.is(Package) then
         registerSymbol(sym, symkinds)
-
-    private def namePresentInSource(sym: Symbol, span: Span, source:SourceFile)(using Context): Boolean =
-      if !span.exists then false
-      else
-        val content = source.content()
-        val (start, end) =
-          if content.lift(span.end - 1).exists(_ == '`') then
-            (span.start + 1, span.end - 1)
-          else (span.start, span.end)
-        val nameInSource = content.slice(start, end).mkString
-        // for secondary constructors `this`
-        if sym.isConstructor && nameInSource == nme.THISkw.toString then
-          true
-        else
-          val target =
-            if sym.isPackageObject then sym.owner
-            else sym
-          nameInSource == target.name.stripModuleClassSuffix.lastPart.toString
 
     private def spanOfSymbol(sym: Symbol, span: Span, treeSource: SourceFile)(using Context): Span =
       val contents = if treeSource.exists then treeSource.content() else Array.empty[Char]

--- a/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/Scala3.scala
@@ -36,6 +36,24 @@ object Scala3:
     val (endLine, endCol) = lineCol(span.end)
     Some(Range(startLine, startCol, endLine, endCol))
 
+  def namePresentInSource(sym: Symbol, span: Span, source:SourceFile)(using Context): Boolean =
+    if !span.exists then false
+    else
+      val content = source.content()
+      val (start, end) =
+        if content.lift(span.end - 1).exists(_ == '`') then
+          (span.start + 1, span.end - 1)
+        else (span.start, span.end)
+      val nameInSource = content.slice(start, end).mkString
+      // for secondary constructors `this`
+      if sym.isConstructor && nameInSource == nme.THISkw.toString then
+        true
+      else
+        val target =
+          if sym.isPackageObject then sym.owner
+          else sym
+        nameInSource == target.name.stripModuleClassSuffix.lastPart.toString
+
   sealed trait FakeSymbol {
     private[Scala3] var sname: Option[String] = None
   }
@@ -229,12 +247,6 @@ object Scala3:
       /** Synthetic symbols that are not anonymous or numbered empty ident */
       def isSyntheticWithIdent(using Context): Boolean =
         sym.is(Synthetic) && !sym.isAnonymous && !sym.name.isEmptyNumbered
-
-      /** Check if the symbol is invented by Desugar.inventGivenOrExtensionName
-       *  return true if the symbol is defined as `given Int = ...` and name is invented as "given_Int"
-       */
-      def isInventedGiven(using Context): Boolean =
-        sym.is(Given) && sym.name.startsWith("given_")
 
       /** The semanticdb name of the given symbol */
       def symbolName(using builder: SemanticSymbolBuilder)(using Context): String =
@@ -497,5 +509,17 @@ object Scala3:
     end toDigit
 
   end IdentifierOrdering
+
+  /** Check if the symbol is invented by Desugar.inventGivenOrExtensionName
+   *  return true if the symbol is defined as `given Int = ...` and name is invented as "given_Int"
+   */
+  def isInventedGiven(tree: tpd.Tree)(using Context): Boolean =
+    tree match
+      case tree: tpd.ValDef =>
+        val sym = tree.symbol
+        sym.is(Given) &&
+          sym.name.startsWith("given_") &&
+          !namePresentInSource(sym, tree.nameSpan, tree.source)
+      case _ => false
 
 end Scala3

--- a/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
@@ -15,7 +15,7 @@ class SyntheticsExtractor:
     extension (synth: s.Synthetic)
       def toOpt: Some[s.Synthetic] = Some(synth)
 
-    if tree.span.isSynthetic || tree.symbol.isInventedGiven then
+    if tree.span.isSynthetic || isInventedGiven(tree) then
       tree match
         case tree: Apply if isForSynthetic(tree) =>
           None // not yet supported (for synthetics)

--- a/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
@@ -33,6 +33,18 @@ class SyntheticsExtractor:
             )
           ).toOpt
 
+        case tree: Apply if tree.fun.symbol.is(Implicit) =>
+          val pos = range(tree.span, tree.source)
+          s.Synthetic(
+            pos,
+            s.ApplyTree(
+              tree.fun.toSemanticTree,
+              arguments = List(
+                s.OriginalTree(pos)
+              )
+            )
+          ).toOpt
+
         // Anonymous context parameter
         case tree: ValDef if tree.symbol.is(Given) =>
           s.Synthetic(

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -50,6 +50,7 @@ Text => empty
 Language => Scala
 Symbols => 46 entries
 Occurrences => 101 entries
+Synthetics => 3 entries
 
 Symbols:
 advanced/C# => class C [typeparam T ] extends Object { self: C[T] => +3 decls }
@@ -201,6 +202,11 @@ Occurrences:
 [48:28..48:34): String -> scala/Predef.String#
 [48:37..48:38): x -> advanced/HKClass#foo().(x)
 [48:39..48:47): toString -> scala/Tuple2#toString().
+
+Synthetics:
+[26:12..26:16):s.s1 => reflectiveSelectable(*)
+[28:12..28:16):s.s2 => reflectiveSelectable(*)
+[30:12..30:16):s.s3 => reflectiveSelectable(*)
 
 expect/Annotations.scala
 ------------------------
@@ -1508,6 +1514,7 @@ Text => empty
 Language => Scala
 Symbols => 23 entries
 Occurrences => 48 entries
+Synthetics => 6 entries
 
 Symbols:
 example/ImplicitConversion# => class ImplicitConversion extends Object { self: ImplicitConversion => +9 decls }
@@ -1583,6 +1590,16 @@ Occurrences:
 [34:50..34:54): self -> example/ImplicitConversion.newAny2stringadd#self.
 [34:56..34:57): + -> java/lang/String#`+`().
 [34:58..34:63): other -> example/ImplicitConversion.newAny2stringadd#`+`().(other)
+
+Synthetics:
+[15:2..15:9):message => augmentString(*)
+[17:2..17:7):tuple => newAny2stringadd[Tuple2[Int, Int]](*)
+[20:15..20:22):message => string2Number(*)
+[24:2..26:16):s"""Hello
+     |$message
+     |$number""" => augmentString(*)
+[28:15..28:19):char => char2int(*)
+[29:16..29:20):char => char2long(*)
 
 expect/Imports.scala
 --------------------
@@ -1819,7 +1836,7 @@ Text => empty
 Language => Scala
 Symbols => 7 entries
 Occurrences => 22 entries
-Synthetics => 2 entries
+Synthetics => 3 entries
 
 Symbols:
 example/Issue1749# => class Issue1749 extends Object { self: Issue1749 => +3 decls }
@@ -1855,6 +1872,7 @@ Occurrences:
 [14:2..14:5): map -> example/Issue1854#map.
 
 Synthetics:
+[8:2..8:10):(x1, x1) => orderingToOrdered[Tuple2[Int, Int]](*)
 [8:2..8:10):(x1, x1) => *(Tuple2(Int, Int))
 [8:10..8:10): => *(Int, Int)
 
@@ -2939,7 +2957,7 @@ Text => empty
 Language => Scala
 Symbols => 52 entries
 Occurrences => 133 entries
-Synthetics => 9 entries
+Synthetics => 24 entries
 
 Symbols:
 example/Synthetic# => class Synthetic extends Object { self: Synthetic => +23 decls }
@@ -3131,7 +3149,22 @@ Occurrences:
 [58:6..58:9): foo -> example/Synthetic#Contexts.foo().
 
 Synthetics:
+[6:2..6:18):Array.empty[Int] => intArrayOps(*)
+[7:2..7:8):"fooo" => augmentString(*)
+[10:13..10:24):"name:(.*)" => augmentString(*)
+[13:8..13:28):2 #:: LazyList.empty => toDeferrer[Int](*)
+[13:14..13:28):LazyList.empty => toDeferrer[Nothing](*)
+[17:18..17:38):2 #:: LazyList.empty => toDeferrer[Int](*)
+[17:24..17:38):LazyList.empty => toDeferrer[Nothing](*)
+[19:12..19:13):1 => intWrapper(*)
+[19:26..19:27):0 => intWrapper(*)
+[19:46..19:47):x => ArrowAssoc[Int](*)
+[20:12..20:13):1 => intWrapper(*)
+[20:26..20:27):0 => intWrapper(*)
+[21:12..21:13):1 => intWrapper(*)
+[21:26..21:27):0 => intWrapper(*)
 [32:35..32:49):Array.empty[T] => *(evidence$1)
+[36:22..36:27):new F => orderingToOrdered[F](*)
 [36:22..36:27):new F => *(ordering)
 [50:26..50:29):Int => x$2
 [51:17..51:20):Int => x$1
@@ -4549,7 +4582,7 @@ Text => empty
 Language => Scala
 Symbols => 19 entries
 Occurrences => 34 entries
-Synthetics => 1 entries
+Synthetics => 2 entries
 
 Symbols:
 _empty_/MyProgram# => final class MyProgram extends Object { self: MyProgram => +2 decls }
@@ -4610,4 +4643,5 @@ Occurrences:
 
 Synthetics:
 [5:0..5:0): => *(given_FromString_Int)
+[5:41..5:42):1 => intWrapper(*)
 

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -1705,7 +1705,7 @@ Text => empty
 Language => Scala
 Symbols => 45 entries
 Occurrences => 61 entries
-Synthetics => 7 entries
+Synthetics => 5 entries
 
 Symbols:
 givens/InventedNames$package. => final package object givens extends Object { self: givens.type => +24 decls }
@@ -1820,8 +1820,6 @@ Occurrences:
 Synthetics:
 [14:0..14:20):given String = "str" => given_String
 [15:13..15:16):Int => x$1
-[17:0..17:28):given given_Char: Char = '?' => given_Char
-[18:0..18:32):given `given_Float`: Float = 3.0 => given_Float
 [24:13..24:14):X => x$1
 [34:8..34:20):given_Double => *(intValue)
 [40:8..40:15):given_Y => *(given_X)


### PR DESCRIPTION
```scala
"fooo".stripPrefix("o")

// synthetic
Synthetic(
  <"fooo">,
  ApplyTree(
    IdTree(<Predef.augmentString>),
    List(OriginalTree(<"fooo">))))
```

https://github.com/lampepfl/dotty/issues/13135